### PR TITLE
fix: Resolve inconsistent path issue when running via crontab

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 from .logger import log
 
-ROOT_PATH = Path(__name__).parent.absolute()
+ROOT_PATH = Path(__file__).parent.parent.absolute()
 
 DATA_PATH = ROOT_PATH / "data"
 """数据保存目录"""


### PR DESCRIPTION
修復 使用 crontab 執行腳本時路徑不一致的問題(Ubuntu 20.04)

### 修改前
直接執行腳本路徑
```
ROOT_PATH: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2
DATA_PATH: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2/data
config.yaml: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2/data/config.yaml
```
crontab路徑
```
ROOT_PATH: /home/ubuntu
DATA_PATH: /home/ubuntu/data
config.yaml: /home/ubuntu/data/config.yaml
```

### 修改後
直接執行腳本與crontab路徑一致
```
ROOT_PATH: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2
DATA_PATH: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2/data
config.yaml: /home/ubuntu/miui-auto-tasks-1.7.3-hotfix2/data/config.yaml
```
