### PR TITLE
Update requirements.txt Double requirement given

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ onepush==1.3.0
 orjson==3.9.15
 pydantic==2.5.2
 PyYAML==6.0.1
-qrcode==7.4.2
 tenacity==8.2.3
 qrcode>=7.4.2
 requests_toolbelt


### PR DESCRIPTION
Double requirement given

``` shell
root@ubuntu204:~/miui-auto-tasks# pip install -r requirements.txt
ERROR: Double requirement given: qrcode>=7.4.2 (from -r requirements.txt (line 10)) (already in qrcode==7.4.2 (from -r requirements.txt (line 8)), name='qrcode')
```